### PR TITLE
Add mech missile targeting with visual line

### DIFF
--- a/style.css
+++ b/style.css
@@ -173,6 +173,7 @@ body {
   background: rgba(0,0,0,0.3);
   padding: 10px;
   border-radius: 10px;
+  position: relative;
 }
 
 .map-cell {
@@ -205,6 +206,20 @@ body {
 .map-cell.selected {
   background: #ffeb3b !important;
   box-shadow: 0 0 10px #ffeb3b;
+}
+
+.attack-layer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.attack-layer line {
+  stroke: #ffeb3b;
+  stroke-width: 3;
 }
 
 /* SVGキャラクターのスタイル */


### PR DESCRIPTION
## Summary
- Add mech turn with tap-targeted missile attacks
- Scale mech attack to one third of enemy attack power
- Draw temporary line between mech and target

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d564ea7e08330a99c7e49b7f34008